### PR TITLE
fix getting local hero for online matches

### DIFF
--- a/dota-cheat/context/mem.hpp
+++ b/dota-cheat/context/mem.hpp
@@ -20,6 +20,11 @@ namespace CTX
 		{
 			ADD_ADDRESS( pfnOnColorChanged, CLIENT_DLL, "E8 ? ? ? ? 48 83 C6 7C" ).Jump( );
 		} C_BaseModelEntity;
+
+		struct
+		{
+			ADD_ADDRESS( pfnDtor, CLIENT_DLL, "48 89 5C 24 08 57 48 83 EC 20 8B DA 48 8B F9 E8 2C 00 00 00 F6 C3 01 74 0D BA 98 0D 00 00 48 8B CF" );
+		} CBasePlayerController;
 	};
 
 	inline std::optional< Memory_t > Memory = std::nullopt; // @note xnxkzeu: std::optional is used here to delay initialization.

--- a/dota-cheat/core/entities.hpp
+++ b/dota-cheat/core/entities.hpp
@@ -53,7 +53,13 @@ public:
 	SCHEMA_VARIABLE( "C_DOTA_BaseNPC_Hero", "m_hReplicatingOtherHeroModel", GetReplicatingHeroHandle, CEntityHandle );
 };
 
-class C_DOTAPlayerController : public C_BaseEntity
+class CBasePlayerController : public C_BaseEntity
+{
+public:
+	SCHEMA_VARIABLE( "CBasePlayerController", "m_bIsLocalPlayerController", GetIsLocalPlayerController, bool );
+};
+
+class C_DOTAPlayerController : public CBasePlayerController
 {
 public:
 	SCHEMA_VARIABLE( "C_DOTAPlayerController", "m_hAssignedHero", GetAssignedHeroHandle, CEntityHandle );

--- a/dota-cheat/dota-cheat.vcxproj
+++ b/dota-cheat/dota-cheat.vcxproj
@@ -150,6 +150,7 @@
     <ClCompile Include="dependencies\minhook\src\trampoline.c" />
     <ClCompile Include="dllmain.cpp" />
     <ClCompile Include="features\visuals.cpp" />
+    <ClCompile Include="hooks\functions\cbaseplayercontroller.cpp" />
     <ClCompile Include="hooks\functions\present.cpp" />
     <ClCompile Include="hooks\functions\onrenderstart.cpp" />
     <ClCompile Include="hooks\functions\resizebuffers.cpp" />

--- a/dota-cheat/features/visuals.hpp
+++ b/dota-cheat/features/visuals.hpp
@@ -3,6 +3,7 @@
 #include <memory>
 
 class C_DOTA_BaseNPC_Hero;
+class C_DOTAPlayerController;
 
 class CVisuals
 {
@@ -16,7 +17,9 @@ private:
 	void HighlightIllusions( C_DOTA_BaseNPC_Hero* pHero ) const;
 	void VisibleByEnemy( ) const;
 
+public:
 	C_DOTA_BaseNPC_Hero* m_pLocalHero = nullptr;
+	C_DOTAPlayerController* m_pLocalPlayerController = nullptr;
 };
 
 inline std::unique_ptr< CVisuals > pVisuals = nullptr;

--- a/dota-cheat/hooks/functions/cbaseplayercontroller.cpp
+++ b/dota-cheat/hooks/functions/cbaseplayercontroller.cpp
@@ -1,0 +1,14 @@
+#include "../hooks.hpp"
+
+#include "../../features/visuals.hpp"
+
+int64_t HookHandler_t::OnCBasePlayerControllerDtor(void* pPlayerControllerInstance, char a2)
+{
+	if (pVisuals->m_pLocalPlayerController == pPlayerControllerInstance)
+	{
+		pVisuals->m_pLocalPlayerController = nullptr;
+		pVisuals->m_pLocalHero = nullptr;
+	}
+
+	return Hooks::Get().m_pfnOnCBasePlayerControllerDtor(pPlayerControllerInstance, a2);
+}

--- a/dota-cheat/hooks/hooks.hpp
+++ b/dota-cheat/hooks/hooks.hpp
@@ -55,8 +55,12 @@ struct HookHandler_t
 	static HRESULT __stdcall Present( IDXGISwapChain* pSwapchain, UINT unSyncInterval, UINT unFlags );
 	static HRESULT __stdcall ResizeBuffers( IDXGISwapChain* pSwapchain, UINT unBufferCount, UINT unWidth, UINT unHeight, int nNewFormat, UINT unSwapchainFlags );
 
+	static int64_t __fastcall  OnCBasePlayerControllerDtor(void* pPlayerControllerInstance, char a2);
+
 	HOOK_VIRTUAL_FUNCTION( CTX::DOTA->m_pViewRender, 4, OnRenderStart );
 
 	HOOK_FUNCTION( CTX::Memory->IDXGISwapChain.pfnPresent, Present );
 	HOOK_FUNCTION( CTX::Memory->IDXGISwapChain.pfnResizeBuffers, ResizeBuffers );
+
+	HOOK_FUNCTION( CTX::Memory->CBasePlayerController.pfnDtor, OnCBasePlayerControllerDtor);
 };


### PR DESCRIPTION
Hi, thanks for this awesome free open-source cheat @xnxkzeu ! :)
During online play cheat features didn't work for me, so I've attempted to implement a fix.

--

It appears that CTX::DOTA->m_pEngineClient->GetLocalPlayer() doesn't work during online matches (always returns -1).

Therefore instead of using GetLocalPlayer(), iterate on dota_player_controller entities and use GetIsLocalPlayerController() to determine the local player controller.

Hook the CBasePlayerController destructor ( not 100% sure but seems to work ok  ) to reset stored m_pLocalPlayerController & m_pLocalHero upon controller destruction.

Signature introduced for the hook is pretty lazy, might need some tweaking on later updates...